### PR TITLE
feat: Using headers received in the initial request

### DIFF
--- a/lib/engines/puppeteer.js
+++ b/lib/engines/puppeteer.js
@@ -39,6 +39,9 @@ class Puppeteer extends engine.Engine {
         const trim = req.query.trim === "1";
         const method = req.query.method || req.method;
         const body = req.body || null;
+        const headers = req.headers?.["content-type"]
+            ? { "content-type": req.headers?.["content-type"] }
+            : {};
         const width = parseInt(req.query.width || 800);
         const height = parseInt(req.query.width || 600);
         const scaleFactor = parseInt(req.query.scale_factor || 1);
@@ -100,6 +103,7 @@ class Puppeteer extends engine.Engine {
         }
 
         try {
+            page.setExtraHTTPHeaders(headers);
             await page.setViewport({
                 width: width,
                 height: height,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The headers sent in the request are being ignored. This causes an issue when we want to send for a example a `"content-type": "application/json"`. |
| Decisions | Setting the puppeteer headers with `content-type` if  its defined in the initial request. |