### PR TITLE
Fix memory leak in PDF render

### DIFF
--- a/lib/engines/puppeteer.js
+++ b/lib/engines/puppeteer.js
@@ -142,8 +142,10 @@ class Puppeteer extends engine.Engine {
                     printBackground: printBackground
                 });
                 await new Promise(function(resolve, reject) {
+                    res.on("finish", resolve);
+                    res.on("error", reject);
                     res.type("pdf");
-                    res.send(data, {}, resolve);
+                    res.send(data);
                 });
             } else {
                 await page.screenshot({


### PR DESCRIPTION
There is a small mistake in `res.send(data, {}, resolve)`. [Looking at the official docs](http://expressjs.com/en/4x/api.html#res.send) `res.send()` actually receives only 1 argument and not 3 as it's implemented.

If we do `res.send(data, {}, resolve);`, the promise's `resolve()` will never be called, and neither `finally { await page.close(); }`.

This unresolved promise causes all created `page` instances from each request to never close and leads to a memory leak behavior, eating memory that is never freed.

In this proposal, it's ensured that the Promise is properly resolved or rejected and that the `finally` block is reached to close the page instance and release the associated resources.

Since `await page.close();` can be called before `res.send`, we could simplify this fix even more by not using the promise. We could also omit the `error` event since the `finish` is always called in any case.

I still chose this implementation because it was the solution that most closely aligned with the original intention.