### PR TITLE
fix: puppeteer 20.x dropped support for node14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Docker images updated - Puppeteer just dropped node14 support 
+* Docker images updated - Puppeteer just dropped node14 support
 
 ## [0.2.5] - 2023-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Docker images updated - Puppeteer just dropped node14 support 
 
 ## [0.2.5] - 2023-04-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD lib /app/lib
 
 WORKDIR /app
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN DEBIAN_FRONTEND=noninteractive apt-get update &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 fontconfig\
     libpangocairo-1.0-0 nodejs

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -18,7 +18,7 @@ WORKDIR /app
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget curl
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 fontconfig\
     libpangocairo-1.0-0 nodejs
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gconf-service\


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v20.0.0

* https://github.com/puppeteer/puppeteer/pull/10019